### PR TITLE
Key mgmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.zip
 key.txt
 *.Rhistory
+.Rproj.user

--- a/scripts/api_key.R
+++ b/scripts/api_key.R
@@ -1,0 +1,57 @@
+# Path to where key file is stored by acs package.
+acs_key_path <- function(file = "key.Rda") {
+    system.file(paste0("extdata/", file), package="acs")
+}
+
+# Read ASC API key from file
+read_api_key <- function(file) {
+    readChar(file, file.info(file)$size - 1)
+}
+
+#' Retrieve installed ACS API key
+#'
+#' @param file The filename for the installed ACS API key
+retrieve_api_key <- function(file = "key.Rda") {
+    if (have_api_key(file)) {
+        load(acs_key_path(file))
+        key
+    } else {
+        NA
+    }
+}
+
+#' Test if ACS API is installed.
+#'
+#' @param file The filename for the installed ACS API key
+#'
+#' @seealso \code{\link{load_api_key}} for loading from file,
+#'   and \code{\link{enter_api_key}} for entering with interactive prompt.
+have_api_key <- function(file = "key.Rda") {
+    file_test("-f", acs_key_path(file))
+}
+
+#' Prompt user to update ASC API key.
+#'
+#' @param file The filename for the installed ACS API key
+#'
+#' @seealso \code{\link{load_api_key}} for loading from file.
+enter_api_key <- function(file = "key.Rda") {
+    api_key <- readline(prompt = "Enter API key: ")
+    acs::api.key.install(api_key, file = file)
+}
+
+#' Load ASC API key from file.
+#'
+#' @param source_file A file containing an ACS API key
+#' @param file The filename for the installed ACS API key
+#'
+#' @seealso \code{\link{enter_api_key}} for entering with interactive prompt.
+load_api_key <- function(source_file,
+                         file = "key.Rda") {
+    if (file_test("-f", source_file)) {
+        api_key <- read_api_key(source_file)
+        acs::api.key.install(api_key, file = file)
+    } else {
+        stop("Invalid key filename.")
+    }
+}

--- a/scripts/get-acs-constr.R
+++ b/scripts/get-acs-constr.R
@@ -8,7 +8,6 @@ ep <- function(x) eval(parse(text = x))
 myFileName <- "./key/key.txt"
 myKey <- readChar(myFileName, file.info(myFileName)$size)
 api.key.install(myKey, file = "key.rda")
-
 constr.ref <- read.csv(file = "data/constructions-lookup.csv",
                        stringsAsFactors = FALSE)
 source("scripts/rename-cols.R")

--- a/scripts/get-acs-constr.R
+++ b/scripts/get-acs-constr.R
@@ -1,5 +1,3 @@
-source("scripts/acs.R")
-
 #-------------------------------------------------------------------------------
 # Load relevant libraries and files
 #-------------------------------------------------------------------------------
@@ -7,11 +5,9 @@ try(setwd(dir = "~/GitHub/acs-constructicon/"), silent = TRUE)
 try(setwd(dir = "/Users/imorey/Documents/GitHub/acs-constructicon/"), silent = TRUE)
 library(acs)
 ep <- function(x) eval(parse(text = x))
-
-my_key_file <- "./key/key.txt"
-if (!have_api_key()) {
-    load_api_key(my_key_file)
-}
+myFileName <- "./key/key.txt"
+myKey <- readChar(myFileName, file.info(myFileName)$size)
+api.key.install(myKey, file = "key.rda")
 
 constr.ref <- read.csv(file = "data/constructions-lookup.csv",
                        stringsAsFactors = FALSE)

--- a/scripts/get-acs-constr.R
+++ b/scripts/get-acs-constr.R
@@ -1,3 +1,5 @@
+source("scripts/acs.R")
+
 #-------------------------------------------------------------------------------
 # Load relevant libraries and files
 #-------------------------------------------------------------------------------
@@ -5,9 +7,12 @@ try(setwd(dir = "~/GitHub/acs-constructicon/"), silent = TRUE)
 try(setwd(dir = "/Users/imorey/Documents/GitHub/acs-constructicon/"), silent = TRUE)
 library(acs)
 ep <- function(x) eval(parse(text = x))
-myFileName <- "./key/key.txt"
-myKey <- readChar(myFileName, file.info(myFileName)$size)
-api.key.install(myKey, file = "key.rda")
+
+my_key_file <- "./key/key.txt"
+if (!have_api_key()) {
+    load_api_key(my_key_file)
+}
+
 constr.ref <- read.csv(file = "data/constructions-lookup.csv",
                        stringsAsFactors = FALSE)
 source("scripts/rename-cols.R")

--- a/vignettes/key_setup.Rmd
+++ b/vignettes/key_setup.Rmd
@@ -1,0 +1,30 @@
+---
+title: "ACS Key Management"
+author: "Dylan Stark"
+output: html_document
+---
+
+You can request a key at the US Census Bureau's [key signup page](http://api.census.gov/data/key_signup.html).
+All you need is an organization name and email address.
+And, after you agree to the terms of service and submit the form, your key will be emailed to you.
+When you receive the API key in an email, all that's left is to click the link active the key.
+
+Now, you should have a key that looks something like `c009d1d366fe5077a7266212f3205b7715745441`.
+Use either the `enter_api_key` or `load_api_key` method to install your new key.
+The former will prompt you to type in (or copy-and-paste) the key.
+The latter will read the key from a file.
+
+For example, in a if you store your key in `Key.txt`, you can test and optionally load in a script with
+
+```r
+if (!have_api_key()) {
+    load_api_key("Key.txt")
+}
+```
+
+Or, if using during an interactive session, try
+
+```r
+> enter_api_key()
+Enter API key: c009d1d366fe5077a7266212f3205b7715745441
+```


### PR DESCRIPTION
I added some helper functions to make installing and loading ACS keys a little easier. There's a method for entering the key in with a prompt and another that wraps the details of reading and installing from a file. Also, there are some helpers for testing whether there's a key installed and retrieving the installed key (which was motivated by my having a hard time diagnosing a problem that came down my installing a bad key).